### PR TITLE
Package jrnl-md as a shell command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "bin": {
+    "jrnl-md": "./dist/index.js"
+  },
   "dependencies": {
     "inversify": "^4.11.1",
     "marked": "^0.3.16",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import * as os from 'os';
 import * as yargs from 'yargs';
 import {Application} from './application';


### PR DESCRIPTION
Fixes #5

Adds the `/usr/bin/env node` shebang to `package.json` and adds a new
`bin` section to `package.json` to have `npm install -g` create the
`jrnl-md` command.